### PR TITLE
drop support for py27.

### DIFF
--- a/s3lib/__init__.py
+++ b/s3lib/__init__.py
@@ -7,15 +7,10 @@ import time
 from xml.etree.ElementTree import fromstring as parse
 from xml.etree.ElementTree import Element, SubElement, tostring
 from s3lib.utils import split_headers, split_args, batchify, take, get_string_to_sign, raise_http_resp_error
-import urllib
+from urllib.parse import quote
 import sys
 import stat
 import os
-
-try:
-  quote = urllib.quote
-except AttributeError:
-  quote = urllib.parse.quote
 
 class Connection:
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 requires =  ['safeoutput>=2.0', 'future', 'docopt']
-test_requires = ['tox', 'pytest']
+test_requires = ['tox', 'pytest==7.2.2']
 
 setup(
     name='S3Lib',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,37}
+envlist = py{37,39}
 recreate = True
 
 [testenv]


### PR DESCRIPTION
Quote now imported normally.
Pin to new version of pytest.
Change tox to use py37,py39 and not py27